### PR TITLE
netdev-tc-offloads: Limit the max action number to 16

### DIFF
--- a/lib/netdev-tc-offloads.c
+++ b/lib/netdev-tc-offloads.c
@@ -1283,8 +1283,8 @@ netdev_tc_flow_put(struct netdev *netdev, struct match *match,
     }
 
     NL_ATTR_FOR_EACH(nla, left, actions, actions_len) {
-        if (flower.action_count >= TCA_ACT_MAX_PRIO) {
-            VLOG_DBG_RL(&rl, "Can only support %d actions", flower.action_count);
+        if (flower.action_count >= TCA_ACT_MAX_NUM) {
+            VLOG_DBG_RL(&rl, "Can only support %d actions", TCA_ACT_MAX_NUM);
             return EOPNOTSUPP;
         }
         action = &flower.actions[flower.action_count];

--- a/lib/tc.c
+++ b/lib/tc.c
@@ -1364,7 +1364,7 @@ static int
 nl_parse_flower_actions(struct nlattr **attrs, struct tc_flower *flower)
 {
     const struct nlattr *actions = attrs[TCA_FLOWER_ACT];
-    static struct nl_policy actions_orders_policy[TCA_ACT_MAX_PRIO + 1] = {};
+    static struct nl_policy actions_orders_policy[TCA_ACT_MAX_NUM + 1] = {};
     struct nlattr *actions_orders[ARRAY_SIZE(actions_orders_policy)];
     const int max_size = ARRAY_SIZE(actions_orders_policy);
 
@@ -1383,8 +1383,8 @@ nl_parse_flower_actions(struct nlattr **attrs, struct tc_flower *flower)
         if (actions_orders[i]) {
             int err;
 
-            if (flower->action_count >= TCA_ACT_MAX_PRIO) {
-                VLOG_DBG_RL(&error_rl, "Can only support %d actions", flower->action_count);
+            if (flower->action_count >= TCA_ACT_MAX_NUM) {
+                VLOG_DBG_RL(&error_rl, "Can only support %d actions", TCA_ACT_MAX_NUM);
                 return EOPNOTSUPP;
             }
             err = nl_parse_single_action(actions_orders[i], flower);

--- a/lib/tc.h
+++ b/lib/tc.h
@@ -214,6 +214,8 @@ enum tc_offloaded_state {
     TC_OFFLOADED_STATE_NOT_IN_HW,
 };
 
+#define TCA_ACT_MAX_NUM 16
+
 struct tc_flower {
     uint32_t chain;
     uint32_t prio;
@@ -223,7 +225,7 @@ struct tc_flower {
     struct tc_flower_key mask;
 
     int action_count;
-    struct tc_action actions[TCA_ACT_MAX_PRIO];
+    struct tc_action actions[TCA_ACT_MAX_NUM];
 
     struct ovs_flow_stats stats;
     uint64_t lastused;


### PR DESCRIPTION
If there are 32 actions, tfilter_notify() in tc_new_tfilter() will
return -EINVAL because we only allocate 4K buffer which is not big
enough. If we enlarge it to 8K, there is no problem. But customer
doesn't want to change the kernel. So we limit the max action number
to 16 in ovs to workaround this issue.

If tfilter_notify() returns -EINVAL, recvmsg() will return EAGAIN.
In this case, tc_transact() in tc_replace_flower() will return 0.
But the buffer in reply is NULL. So we'll hit the following assert:

./include/openvswitch/ofpbuf.h:189: assertion offset + size <= b->size failed in ofpbuf_at_assert()

Issue: 1917067
Signed-off-by: Chris Mi <chrism@mellanox.com>