### PR TITLE
Ct one table 2.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ cscope.*
 tags
 _debian
 odp-netlink.h
+odp-netlink-macros.h
 OvsDpInterface.h
 /.vagrant/
 testsuite.tmp.orig

--- a/build-aux/extract-odp-netlink-macros-h
+++ b/build-aux/extract-odp-netlink-macros-h
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+hfile=$1
+
+generate_fields_macros () {
+    local struct_name=$1
+    local line_start
+    local num_lines
+    local line_end
+    local awk_cmd
+    local STRUCT
+
+    # line_start is the line number where the definition of the struct begin
+    # line_end is the line number where the definition of the struct ends
+    line_start=`grep -nw $struct_name $hfile | grep { | cut -d ":" -f1`
+    num_lines=`tail -n +${line_start} $hfile | grep -n -m1 } | cut -d ":" -f1`
+    line_end=$((line_start+num_lines-1))
+
+
+    STRUCT=`echo $struct_name | tr [a-z] [A-Z]`
+    echo "#define ${STRUCT}_OFFSETOF_SIZEOF_ARR { \\"
+    # for all the field lines, including the terminating }, remove ";" and
+    # replace with an item of {offsetof, sizeof}.
+    # 3 awk fields are for type struct <struct name> and field <field_name>
+    # 2 awk fields are for type <type> and field <field_name>
+    # else - terminating the array by item {0, 0}
+    awk_cmd="'{"
+    awk_cmd=$awk_cmd'    if (NF == 3)'
+    awk_cmd=$awk_cmd'        print "    {offsetof(struct '"${struct_name}"', "$3"), sizeof("$1,$2")}, \\";'
+    awk_cmd=$awk_cmd'    else if (NF == 2)'
+    awk_cmd=$awk_cmd'        print "    {offsetof(struct '"${struct_name}"', "$2"), sizeof("   $1")}, \\";'
+    awk_cmd=$awk_cmd'    else'
+    awk_cmd=$awk_cmd'        print "    {0, 0}}";'
+    awk_cmd=$awk_cmd"}'"
+    awk -F ";" "NR>${line_start} && NR<=${line_end}"' {print $1}' $hfile | eval "awk $awk_cmd"
+
+    echo
+    echo
+}
+
+echo "/* Generated automatically from <include/odp-netlink.h> -- do not modify! */"
+echo "#ifndef ODP_NETLINK_MACROS_H"
+echo "#define ODP_NETLINK_MACROS_H"
+echo
+echo
+
+generate_fields_macros "ovs_key_ethernet"
+generate_fields_macros "ovs_key_ipv4"
+generate_fields_macros "ovs_key_ipv6"
+generate_fields_macros "ovs_key_tcp"
+generate_fields_macros "ovs_key_udp"
+generate_fields_macros "ovs_key_sctp"
+generate_fields_macros "ovs_key_icmp"
+generate_fields_macros "ovs_key_icmpv6"
+generate_fields_macros "ovs_key_arp"
+generate_fields_macros "ovs_key_nd"
+generate_fields_macros "ovs_key_nd_extensions"
+
+echo
+echo "#endif"

--- a/include/automake.mk
+++ b/include/automake.mk
@@ -1,10 +1,15 @@
-BUILT_SOURCES += include/odp-netlink.h
+BUILT_SOURCES += include/odp-netlink.h include/odp-netlink-macros.h
 
 include/odp-netlink.h: datapath/linux/compat/include/linux/openvswitch.h \
                        build-aux/extract-odp-netlink-h
 	$(AM_V_GEN)sed -f $(srcdir)/build-aux/extract-odp-netlink-h < $< > $@
-EXTRA_DIST += build-aux/extract-odp-netlink-h
-CLEANFILES += include/odp-netlink.h
+
+include/odp-netlink-macros.h: include/odp-netlink.h \
+                              build-aux/extract-odp-netlink-macros-h
+	$(AM_V_GEN)sh -f $(srcdir)/build-aux/extract-odp-netlink-macros-h $< > $@
+
+EXTRA_DIST += build-aux/extract-odp-netlink-h build-aux/extract-odp-netlink-macros-h
+CLEANFILES += include/odp-netlink.h include/odp-netlink-macros.h
 
 include include/ovn/automake.mk
 include include/openflow/automake.mk

--- a/tests/mpls-xlate.at
+++ b/tests/mpls-xlate.at
@@ -182,7 +182,7 @@ AT_CHECK([ovs-ofctl -O OpenFlow13 add-flow br1 in_port=1,ip,actions=dec_ttl,push
 dnl MPLS push+pop
 AT_CHECK([ovs-appctl ofproto/trace ovs-dummy 'in_port(100),eth(src=f8:bc:12:44:34:b6,dst=f8:bc:12:46:58:e0),eth_type(0x0800),ipv4(src=10.1.1.22,dst=10.0.0.3,proto=6,tos=0,ttl=64,frag=no),tcp(src=53295,dst=8080)'], [0], [stdout])
 AT_CHECK([tail -1 stdout], [0],
-  [Datapath actions: set(ipv4(ttl=63)),push_mpls(label=0,tc=0,ttl=63,bos=1,eth_type=0x8847),3,pop_mpls(eth_type=0x800),set(ipv4(tos=0/0xfc,ttl=64)),1,1
+  [Datapath actions: set(ipv4(ttl=63)),push_mpls(label=0,tc=0,ttl=63,bos=1,eth_type=0x8847),3,pop_mpls(eth_type=0x800),set(ipv4(ttl=64)),1,1
 ])
 
 OVS_VSWITCHD_STOP

--- a/tests/ofproto-dpif.at
+++ b/tests/ofproto-dpif.at
@@ -4374,7 +4374,7 @@ do
     elif test $type = later; then
         echo "Datapath actions: $exp_output" >> expout
     else
-        echo "Datapath actions: set(tcp(src=80,dst=80)),$exp_output" >> expout
+        echo "Datapath actions: set(tcp(src=80)),$exp_output" >> expout
     fi
     AT_CHECK([grep 'IP fragments' stdout; tail -1 stdout], [0], [expout])
   done
@@ -7280,7 +7280,7 @@ AT_CHECK([ovs-ofctl add-flows br0 flows.txt], [0], [ignore])
 AT_CHECK([ovs-appctl ofproto/trace ovs-dummy 'in_port(1),eth(src=50:54:00:00:00:09,dst=50:54:00:00:00:0a),eth_type(0x0800),ipv4(src=10.10.10.2,dst=10.10.10.1,proto=1,tos=1,ttl=128,frag=no),icmp(type=8,code=0)'], [0], [stdout])
 
 AT_CHECK([tail -1 stdout], [0], [dnl
-Datapath actions: set(ipv4(src=10.10.10.2,dst=192.168.4.4)),2,set(eth(src=80:81:81:81:81:81)),set(ipv4(src=10.10.10.2,dst=192.168.5.5)),3,set(eth(src=50:54:00:00:00:09)),set(ipv4(src=10.10.10.2,dst=10.10.10.1)),4
+Datapath actions: set(ipv4(dst=192.168.4.4)),2,set(eth(src=80:81:81:81:81:81)),set(ipv4(dst=192.168.5.5)),3,set(eth(src=50:54:00:00:00:09)),set(ipv4(dst=10.10.10.1)),4
 ])
 
 dnl Test flow xlate openflow clone action without using datapath clone action.
@@ -7289,14 +7289,14 @@ AT_CHECK([ovs-appctl dpif/set-dp-features br0 clone false], [0], [ignore])
 AT_CHECK([ovs-appctl ofproto/trace ovs-dummy 'in_port(1),eth(src=50:54:00:00:00:09,dst=50:54:00:00:00:0a),eth_type(0x0800),ipv4(src=10.10.10.2,dst=10.10.10.1,proto=1,tos=1,ttl=128,frag=no),icmp(type=8,code=0)'], [0], [stdout])
 
 AT_CHECK([tail -1 stdout], [0], [dnl
-Datapath actions: set(ipv4(src=10.10.10.2,dst=192.168.4.4)),2,set(eth(src=80:81:81:81:81:81)),set(ipv4(src=10.10.10.2,dst=192.168.5.5)),3,set(eth(src=50:54:00:00:00:09)),set(ipv4(src=10.10.10.2,dst=10.10.10.1)),4
+Datapath actions: set(ipv4(dst=192.168.4.4)),2,set(eth(src=80:81:81:81:81:81)),set(ipv4(dst=192.168.5.5)),3,set(eth(src=50:54:00:00:00:09)),set(ipv4(dst=10.10.10.1)),4
 ])
 
 AT_CHECK([ovs-appctl dpif/set-dp-features br0 sample_nesting 2], [0], [ignore])
 AT_CHECK([ovs-appctl ofproto/trace ovs-dummy 'in_port(1),eth(src=50:54:00:00:00:09,dst=50:54:00:00:00:0a),eth_type(0x0800),ipv4(src=10.10.10.2,dst=10.10.10.1,proto=1,tos=1,ttl=128,frag=no),icmp(type=8,code=0)'], [0], [stdout])
 
 AT_CHECK([tail -1 stdout], [0], [dnl
-Datapath actions: set(ipv4(src=10.10.10.2,dst=192.168.4.4)),2,set(eth(src=80:81:81:81:81:81)),set(ipv4(src=10.10.10.2,dst=192.168.5.5)),3,set(eth(src=50:54:00:00:00:09)),set(ipv4(src=10.10.10.2,dst=10.10.10.1)),4
+Datapath actions: set(ipv4(dst=192.168.4.4)),2,set(eth(src=80:81:81:81:81:81)),set(ipv4(dst=192.168.5.5)),3,set(eth(src=50:54:00:00:00:09)),set(ipv4(dst=10.10.10.1)),4
 ])
 
 dnl Mixing reversible and irreversible open flow clone actions. Datapath clone action
@@ -7314,7 +7314,7 @@ AT_CHECK([ovs-ofctl add-flows br0 flows.txt], [0], [ignore])
 AT_CHECK([ovs-appctl ofproto/trace ovs-dummy 'in_port(1),eth(src=50:54:00:00:00:09,dst=50:54:00:00:00:0a),eth_type(0x0800),ipv4(src=10.10.10.2,dst=10.10.10.1,proto=1,tos=1,ttl=128,frag=no),icmp(type=8,code=0)'], [0], [stdout])
 
 AT_CHECK([tail -1 stdout], [0], [dnl
-Datapath actions: set(ipv4(src=10.10.10.2,dst=192.168.4.4)),2,set(ipv4(src=10.10.10.2,dst=10.10.10.1)),clone(ct(commit),3),4
+Datapath actions: set(ipv4(dst=192.168.4.4)),2,set(ipv4(dst=10.10.10.1)),clone(ct(commit),3),4
 ])
 
 AT_CHECK([ovs-appctl dpif/set-dp-features br0 clone false], [0], [ignore])
@@ -7322,14 +7322,14 @@ AT_CHECK([ovs-appctl dpif/set-dp-features br0 clone false], [0], [ignore])
 AT_CHECK([ovs-appctl ofproto/trace ovs-dummy 'in_port(1),eth(src=50:54:00:00:00:09,dst=50:54:00:00:00:0a),eth_type(0x0800),ipv4(src=10.10.10.2,dst=10.10.10.1,proto=1,tos=1,ttl=128,frag=no),icmp(type=8,code=0)'], [0], [stdout])
 
 AT_CHECK([tail -1 stdout], [0], [dnl
-Datapath actions: set(ipv4(src=10.10.10.2,dst=192.168.4.4)),2,set(ipv4(src=10.10.10.2,dst=10.10.10.1)),sample(sample=100.0%,actions(ct(commit),3)),4
+Datapath actions: set(ipv4(dst=192.168.4.4)),2,set(ipv4(dst=10.10.10.1)),sample(sample=100.0%,actions(ct(commit),3)),4
 ])
 
 AT_CHECK([ovs-appctl dpif/set-dp-features br0 sample_nesting 2], [0], [ignore])
 AT_CHECK([ovs-appctl ofproto/trace ovs-dummy 'in_port(1),eth(src=50:54:00:00:00:09,dst=50:54:00:00:00:0a),eth_type(0x0800),ipv4(src=10.10.10.2,dst=10.10.10.1,proto=1,tos=1,ttl=128,frag=no),icmp(type=8,code=0)'], [0], [stdout])
 
 AT_CHECK([tail -1 stdout], [0], [dnl
-Datapath actions: set(ipv4(src=10.10.10.2,dst=192.168.4.4)),2,set(ipv4(src=10.10.10.2,dst=10.10.10.1)),4
+Datapath actions: set(ipv4(dst=192.168.4.4)),2,set(ipv4(dst=10.10.10.1)),4
 ])
 AT_CHECK([grep "Failed to compose clone action" stdout], [0], [ignore])
 


### PR DESCRIPTION
Cherry-pick the following two commits from upstream.

odp-util: Do not rewrite fields with the same values as matched
Makefiles: Generate datapath ovs key fields macros

No big change. Only two small conflicts.